### PR TITLE
Fix: Correct ICD display and selection in clinical history forms

### DIFF
--- a/templates/editar_historia.html
+++ b/templates/editar_historia.html
@@ -10,14 +10,6 @@
         <input type="text" class="form-control" id="motivo" name="motivo" value="{{ historia.motivo }}" required>
       </div>
       <div class="mb-3">
-        <label for="diagnostico" class="form-label">Diagnóstico</label>
-        <input type="text" class="form-control" id="diagnostico" name="diagnostico" value="{{ historia.diagnostico }}">
-      </div>
-      <div class="mb-3">
-        <label for="tratamiento" class="form-label">Tratamiento</label>
-        <input type="text" class="form-control" id="tratamiento" name="tratamiento" value="{{ historia.tratamiento }}">
-      </div>
-      <div class="mb-3">
         <label for="observaciones" class="form-label">Observaciones</label>
         <textarea class="form-control" id="observaciones" name="observaciones" rows="4">{{ historia.observaciones }}</textarea>
       </div>

--- a/templates/nueva_historia.html
+++ b/templates/nueva_historia.html
@@ -10,14 +10,6 @@
         <input type="text" class="form-control" id="motivo" name="motivo" placeholder="Ingrese el motivo de consulta" required>
       </div>
       <div class="mb-3">
-        <label for="diagnostico" class="form-label">Diagnóstico</label>
-        <input type="text" class="form-control" id="diagnostico" name="diagnostico" placeholder="Ingrese el diagnóstico">
-      </div>
-      <div class="mb-3">
-        <label for="tratamiento" class="form-label">Tratamiento</label>
-        <input type="text" class="form-control" id="tratamiento" name="tratamiento" placeholder="Ingrese el tratamiento">
-      </div>
-      <div class="mb-3">
         <label for="observaciones" class="form-label">Observaciones</label>
         <textarea class="form-control" id="observaciones" name="observaciones" rows="4" placeholder="Ingrese observaciones adicionales"></textarea>
       </div>

--- a/test_app.py
+++ b/test_app.py
@@ -8,9 +8,10 @@ from unittest.mock import patch, MagicMock
 # This might be needed if 'index' or 'models' are not in the Python path during testing
 # import sys
 # sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))) # Adjust as needed
+from flask import url_for
 
 from index import app, db
-from models import Paciente, HistoriaClinica, User # Assuming User is needed for context or future tests
+from models import Paciente, HistoriaClinica, User, Diagnostico, Tratamiento # Added Diagnostico, Tratamiento
 from icd_api_service import search_icd_codes
 
 class BaseTestCase(unittest.TestCase):
@@ -38,8 +39,9 @@ class BaseTestCase(unittest.TestCase):
             # Clear all data from tables before each test
             # For more complex scenarios, consider transactions or selective deletion
             # More aggressive/direct cleanup for tables involved in tests:
-            HistoriaClinica.query.delete() # Delete children first
+            HistoriaClinica.query.delete()
             Paciente.query.delete()
+            Diagnostico.query.delete() # Added Diagnostico cleanup
             # meta = db.metadata
             # for table in reversed(meta.sorted_tables):
             #     db.session.execute(table.delete())
@@ -104,6 +106,88 @@ class PatientDeletionTests(BaseTestCase):
             self.assertIsNone(Paciente.query.get(paciente_id))
             self.assertIsNone(HistoriaClinica.query.get(historia2_id))
             self.assertEqual(HistoriaClinica.query.filter_by(paciente_id=paciente_id).count(), 0)
+
+class ClinicalHistoryFormTests(BaseTestCase):
+    def _login(self, username, password):
+        # Check if user exists, if not create one
+        user = User.query.filter_by(username=username).first()
+        if not user:
+            user = User(username=username)
+            user.set_password(password)
+            db.session.add(user)
+            db.session.commit()
+
+        # Use self.client provided by Flask's test app
+        return self.client.post(url_for('login'), data=dict(
+            username=username,
+            password=password
+        ), follow_redirects=True)
+
+    def setUp(self):
+        super().setUp() # Call BaseTestCase's setUp
+        # Create a test client for making requests
+        self.client = app.test_client()
+        # Create a test user for login, if not already handled by _login or specific tests
+        # For simplicity, _login will handle user creation if needed.
+
+    def test_nueva_historia_form_loads_diagnosticos_dropdown(self):
+        with app.app_context():
+            self._login('testuserform', 'password123')
+
+            paciente_doc = f"FORMTEST_{time.time()}"
+            paciente = Paciente(nombre='Test Paciente Form', edad=30, documento=paciente_doc)
+            db.session.add(paciente)
+            db.session.commit()
+
+            diag1_code = f"TEST01_{time.time()}"
+            diag1 = Diagnostico(codigo=diag1_code, descripcion='Test Diagnostico Uno')
+            db.session.add(diag1)
+            db.session.commit()
+
+            response = self.client.get(url_for('nueva_historia', paciente_id=paciente.id))
+
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(b'id="diagnosticos_seleccionados"', response.data)
+            self.assertIn(b'name="diagnosticos_seleccionados"', response.data)
+            self.assertIn(b'Test Diagnostico Uno', response.data)
+            self.assertIn(diag1_code.encode('utf-8'), response.data)
+
+            # Clean up (optional here as setUp clears tables, but good for explicitness if needed)
+            # db.session.delete(diag1)
+            # db.session.delete(paciente)
+            # db.session.commit()
+
+    def test_editar_historia_form_loads_diagnosticos_dropdown(self):
+        with app.app_context():
+            self._login('testuserformedit', 'password123')
+
+            paciente_doc_edit = f"FORMEDIT_{time.time()}"
+            paciente = Paciente(nombre='Test Paciente Edit Form', edad=31, documento=paciente_doc_edit)
+            db.session.add(paciente)
+            db.session.commit() # Commit paciente to get its ID
+
+            historia = HistoriaClinica(motivo='Test Motivo Edit', paciente_id=paciente.id)
+            db.session.add(historia)
+            db.session.commit() # Commit historia to get its ID
+
+            diag2_code = f"TEST02_{time.time()}"
+            diag2 = Diagnostico(codigo=diag2_code, descripcion='Test Diagnostico Dos')
+            db.session.add(diag2)
+            db.session.commit()
+
+            response = self.client.get(url_for('editar_historia', paciente_id=paciente.id, historia_id=historia.id))
+
+            self.assertEqual(response.status_code, 200)
+            self.assertIn(b'id="diagnosticos_seleccionados"', response.data)
+            self.assertIn(b'name="diagnosticos_seleccionados"', response.data)
+            self.assertIn(b'Test Diagnostico Dos', response.data)
+            self.assertIn(diag2_code.encode('utf-8'), response.data)
+
+            # Clean up (optional here)
+            # db.session.delete(diag2)
+            # db.session.delete(historia)
+            # db.session.delete(paciente)
+            # db.session.commit()
 
 # This allows running tests from the command line
 if __name__ == '__main__':


### PR DESCRIPTION
This commit addresses an issue where ICD codes were reportedly not being displayed or implemented correctly when creating or editing clinical histories.

The primary changes include:
- Removed old, non-functional text input fields for 'diagnostico' and 'tratamiento' from the `nueva_historia.html` and `editar_historia.html` templates. These fields were causing confusion as they were no longer connected to the backend models or processing logic.
- The forms now solely rely on the 'diagnosticos_seleccionados' multi-select dropdown, which is populated from the `Diagnostico` table catalog.

Additionally, automated tests have been added to `test_app.py` to:
- Verify that the `diagnosticos_catalogo` is passed to the context of the `nueva_historia` and `editar_historia` routes.
- Ensure the multi-select dropdown for diagnoses is rendered in the forms, including checks for sample diagnostic data.
- Test setup was improved with better data cleanup and a login helper.

These changes clarify the UI for ICD code selection in clinical histories and provide test coverage for this functionality.